### PR TITLE
Document `show` quick wins and define the first small improvement set

### DIFF
--- a/src/bin/show/dto.rs
+++ b/src/bin/show/dto.rs
@@ -115,11 +115,70 @@ impl ShowRequestDto {
         let mode = mode.ok_or("--mode is required")?;
         let target = target.ok_or("--target is required")?;
 
+        if target == ShowTarget::Group {
+            return Err("--target group is not implemented yet".into());
+        }
+
+        if mode == ShowMode::Search && scope.is_none() {
+            return Err("--scope is required with --mode search".into());
+        }
+
+        if mode != ShowMode::Search && scope.is_some() {
+            return Err("--scope is only supported with --mode search".into());
+        }
+
         let mut request = ShowRequestDto::new(mode, target);
         if let Some(s) = scope {
             request = request.with_scope(s);
         }
 
         Ok(request)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn rejects_group_target_until_it_is_implemented() {
+        let result = ShowRequestDto::from_args(&args(&["show", "--mode", "list", "--target", "group"]));
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "--target group is not implemented yet"
+        );
+    }
+
+    #[test]
+    fn rejects_scope_without_search_mode() {
+        let result = ShowRequestDto::from_args(&args(&[
+            "show",
+            "--mode",
+            "list",
+            "--target",
+            "all",
+            "--scope",
+            "@st-foo",
+        ]));
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "--scope is only supported with --mode search"
+        );
+    }
+
+    #[test]
+    fn requires_scope_for_search_mode() {
+        let result = ShowRequestDto::from_args(&args(&["show", "--mode", "search", "--target", "all"]));
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "--scope is required with --mode search"
+        );
     }
 }

--- a/src/bin/show/dto.rs
+++ b/src/bin/show/dto.rs
@@ -86,6 +86,32 @@ impl ShowRequestDto {
         self
     }
 
+    /// Parses command-line style arguments into a `ShowRequestDto`.
+    ///
+    /// Expects an arguments slice where the first element is the program name (it is skipped),
+    /// and recognizes `--mode <value>`, `--target <value>`, and `--scope <value>`. Validates that
+    /// `--mode` and `--target` are provided, rejects `--target group`, requires `--scope` when
+    /// `--mode search` is used, and rejects `--scope` for modes other than `search`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `Err` with a descriptive message for any of:
+    /// - missing value for `--mode`, `--target`, or `--scope` (messages: `"--mode requires a value"`, `"--target requires a value"`, `"--scope requires a value"`),
+    /// - unknown argument (`"Unknown argument: <arg>"`),
+    /// - missing required flags (`"--mode is required"`, `"--target is required"`),
+    /// - unsupported target (`"--target group is not implemented yet"`),
+    /// - missing scope with search mode (`"--scope is required with --mode search"`),
+    /// - scope provided with a non-search mode (`"--scope is only supported with --mode search"`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let argv = vec!["prog".to_string(), "--mode".to_string(), "search".to_string(), "--target".to_string(), "all".to_string(), "--scope".to_string(), "@st-foo".to_string()];
+    /// let req = ShowRequestDto::from_args(&argv).unwrap();
+    /// assert_eq!(req.mode.to_string(), "search");
+    /// assert_eq!(req.target.to_string(), "all");
+    /// assert_eq!(req.scope.unwrap(), "@st-foo".to_string());
+    /// ```
     pub fn from_args(args: &[String]) -> Result<Self, Box<dyn std::error::Error>> {
         let mut mode: Option<ShowMode> = None;
         let mut target: Option<ShowTarget> = None;
@@ -140,6 +166,15 @@ impl ShowRequestDto {
 mod tests {
     use super::*;
 
+    /// Converts a slice of `&str` into an owned `Vec<String>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let input = ["a", "b", "c"];
+    /// let v = args(&input);
+    /// assert_eq!(v, vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+    /// ```
     fn args(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| value.to_string()).collect()
     }

--- a/src/bin/show/main.rs
+++ b/src/bin/show/main.rs
@@ -1,14 +1,17 @@
 /// [@st-code-bin-show-main-file] layer: abstract, type: File, name: main.rs
 mod dto;
 
+use SpecTrail::domains::models::annotation::code_annotation::CodeAnnotation;
+use SpecTrail::domains::models::annotation::document_annotation::DocumentAnnotation;
 use SpecTrail::domains::services::annotation::scanner::ScanWarning;
 use SpecTrail::use_case::show::show_use_case::{
     ShowUseCase, ShowUseCaseRequestDto, ShowUseCaseResponseDto,
 };
 use dto::ShowRequestDto;
 use std::env;
+use std::process;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() {
     env_logger::init();
     let args: Vec<String> = env::args().collect();
 
@@ -16,7 +19,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Ok(request_dto) => request_dto,
         Err(error) => {
             eprintln!("Error: {}", error);
-            return Err(error);
+            process::exit(1);
         }
     };
 
@@ -33,27 +36,64 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     match response {
         Ok(response) => {
-            /* Print scan warnings to stderr to notify the user of any malformed annotations or missing links. */
-            for warning in &response.warnings {
-                match warning {
-                    ScanWarning::Parse(pw) => {
-                        eprintln!(
-                            "WARNING: [{}] Parse error: {} (raw: '{}')",
-                            pw.source_file, pw.message, pw.raw_text
-                        );
-                    }
-                    ScanWarning::Resolve(rw) => {
-                        eprintln!("WARNING: {}", rw.message);
-                    }
-                }
-            }
-
-            println!("Response: {:#?}", response);
-            Ok(())
+            print_warnings(&response.warnings);
+            print_response_summary(&response);
         }
         Err(error) => {
             eprintln!("Error: {}", error);
-            Err(error)
+            process::exit(1);
         }
     }
+}
+
+fn print_warnings(warnings: &[ScanWarning]) {
+    for warning in warnings {
+        match warning {
+            ScanWarning::Parse(pw) => {
+                eprintln!(
+                    "WARNING [parse] {}: {} (raw: '{}')",
+                    pw.source_file, pw.message, pw.raw_text
+                );
+            }
+            ScanWarning::Resolve(rw) => {
+                eprintln!("WARNING [resolve] {}", rw.message);
+            }
+        }
+    }
+}
+
+fn print_response_summary(response: &ShowUseCaseResponseDto) {
+    let code_totals = count_code_annotations(&response.code_annotations);
+    let document_totals = count_document_annotations(&response.document_annotations);
+
+    println!("Show summary");
+    println!("  code files: {}", response.code_annotations.len());
+    println!("  code annotations: {}", code_totals);
+    println!("  document files: {}", response.document_annotations.len());
+    println!("  document annotations: {}", document_totals);
+    println!("  warnings: {}", response.warnings.len());
+}
+
+fn count_code_annotations(annotations: &[CodeAnnotation]) -> usize {
+    annotations
+        .iter()
+        .map(|annotation| {
+            annotation.metas.len()
+                + annotation.abstracts.len()
+                + annotation.details.len()
+                + annotation.implementations.len()
+        })
+        .sum()
+}
+
+fn count_document_annotations(annotations: &[DocumentAnnotation]) -> usize {
+    annotations
+        .iter()
+        .map(|annotation| {
+            annotation.metas.len()
+                + annotation.abstracts.len()
+                + annotation.details.len()
+                + annotation.implementations.len()
+        })
+        .sum()
 }

--- a/src/bin/show/main.rs
+++ b/src/bin/show/main.rs
@@ -11,6 +11,14 @@ use dto::ShowRequestDto;
 use std::env;
 use std::process;
 
+/// Entry point for the `show` CLI: parses command-line arguments, executes the Show use case, and prints any warnings and a compact summary of results.
+///
+/// # Examples
+///
+/// ```no_run
+/// // Run the compiled binary from a shell:
+/// // cargo run --bin show -- <mode> <target> [scope]
+/// ```
 fn main() {
     env_logger::init();
     let args: Vec<String> = env::args().collect();
@@ -46,6 +54,24 @@ fn main() {
     }
 }
 
+/// Prints scan warnings to standard error in a human-readable form.
+///
+/// Parse warnings are printed as:
+/// `WARNING [parse] <source_file>: <message> (raw: '<raw_text>')`
+/// Resolve warnings are printed as:
+/// `WARNING [resolve] <message>`
+///
+/// # Arguments
+///
+/// * `warnings` - Slice of `ScanWarning` values to print.
+///
+/// # Examples
+///
+/// ```
+/// // Assuming `ScanWarning` is in scope:
+/// // print_warnings(&[] as &[crate::ScanWarning]);
+/// print_warnings(&[]);
+/// ```
 fn print_warnings(warnings: &[ScanWarning]) {
     for warning in warnings {
         match warning {
@@ -62,6 +88,22 @@ fn print_warnings(warnings: &[ScanWarning]) {
     }
 }
 
+/// Prints a compact summary of the show use-case response counts to stdout.
+///
+/// The summary includes counts of code files, code annotations, document files,
+/// document annotations, and total warnings from the provided response.
+///
+/// # Examples
+///
+/// ```
+/// // Construct a minimal response with empty collections (types assumed in scope).
+/// let response = ShowUseCaseResponseDto {
+///     code_annotations: Vec::new(),
+///     document_annotations: Vec::new(),
+///     warnings: Vec::new(),
+/// };
+/// print_response_summary(&response);
+/// ```
 fn print_response_summary(response: &ShowUseCaseResponseDto) {
     let code_totals = count_code_annotations(&response.code_annotations);
     let document_totals = count_document_annotations(&response.document_annotations);
@@ -74,6 +116,21 @@ fn print_response_summary(response: &ShowUseCaseResponseDto) {
     println!("  warnings: {}", response.warnings.len());
 }
 
+/// Counts the total number of annotations contained in the given code-file annotations.
+///
+/// The count is the sum, for each `CodeAnnotation`, of its `metas`, `abstracts`,
+/// `details`, and `implementations` collections.
+///
+/// # Examples
+///
+/// ```
+/// // Assuming CodeAnnotation has a simple constructor for tests; replace with
+/// // real constructors in actual code.
+/// use spec_trail_domain::CodeAnnotation;
+///
+/// let annotations: Vec<CodeAnnotation> = vec![];
+/// assert_eq!(crate::count_code_annotations(&annotations), 0);
+/// ```
 fn count_code_annotations(annotations: &[CodeAnnotation]) -> usize {
     annotations
         .iter()
@@ -86,6 +143,13 @@ fn count_code_annotations(annotations: &[CodeAnnotation]) -> usize {
         .sum()
 }
 
+/// Counts all annotations contained in the given document annotations slice.
+///
+/// Returns the total number of `metas`, `abstracts`, `details`, and `implementations` across every `DocumentAnnotation` in `annotations`.
+///
+/// # Returns
+///
+/// `usize` total count of document-level annotation items.
 fn count_document_annotations(annotations: &[DocumentAnnotation]) -> usize {
     annotations
         .iter()

--- a/src/libs/config.rs
+++ b/src/libs/config.rs
@@ -13,6 +13,29 @@ pub struct SpecTrailConfig {
 }
 
 impl SpecTrailConfig {
+    /// Loads a SpecTrailConfig from a TOML file at the specified path.
+    ///
+    /// On success, returns the parsed SpecTrailConfig. File I/O failures or TOML
+    /// deserialization errors are propagated and returned as a boxed dynamic error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::fs;
+    /// let toml = r#"
+    /// [source]
+    /// head = ".specify/"
+    /// extension = "rs"
+    /// [document]
+    /// head = "docs/"
+    /// extension = "md"
+    /// [annotation]
+    /// prefix = "@spec"
+    /// "#;
+    /// fs::write("test_config.toml", toml).unwrap();
+    /// let config = SpecTrailConfig::from_file("test_config.toml").unwrap();
+    /// assert_eq!(config.source.head, ".specify/");
+    /// ```
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, Box<dyn std::error::Error>> {
         let content: String = fs::read_to_string(path)?;
         let config: SpecTrailConfig = toml::from_str(&content)?;

--- a/src/libs/config.rs
+++ b/src/libs/config.rs
@@ -1,5 +1,5 @@
 use serde::Deserialize;
-use std::{fs, io};
+use std::fs;
 use std::path::Path;
 
 /**
@@ -14,23 +14,9 @@ pub struct SpecTrailConfig {
 
 impl SpecTrailConfig {
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, Box<dyn std::error::Error>> {
-        let content_res: io::Result<String> = fs::read_to_string(path);
-        match content_res {
-            Ok(content) => {
-                let config_res: Result<SpecTrailConfig, toml::de::Error> = toml::from_str(&content);
-                match config_res {
-                    Ok(config) => Ok(config),
-                    Err(e) => {
-                        println!("{:?}", e);
-                        Err(Box::new(e))
-                    }
-                }
-            },
-            Err(e) => {
-                println!("{:?}", e);
-                Err(Box::new(e))
-            }
-        }
+        let content: String = fs::read_to_string(path)?;
+        let config: SpecTrailConfig = toml::from_str(&content)?;
+        Ok(config)
     }
 }
 

--- a/src/use_case/show/show_use_case.rs
+++ b/src/use_case/show/show_use_case.rs
@@ -30,6 +30,25 @@ impl ShowUseCase {
         Self
     }
 
+    /// Executes the show use case: scans configured code and document paths according to the request
+    /// and returns found annotations and any scan warnings.
+    ///
+    /// This validates the request options and returns an error for unsupported combinations:
+    /// - mode == "search" -> error "show --mode search is not implemented yet"
+    /// - target == "group" -> error "show --target group is not implemented yet"
+    /// - scope is Some -> error "--scope is only supported with --mode search"
+    ///
+    /// On success, loads configuration from "src/config/config.toml", selects input paths based on
+    /// `request.target`, runs the annotation scanner, reports the results via `report_annotations`,
+    /// and returns a `ShowUseCaseResponseDto` containing document annotations, code annotations, and warnings.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let uc = ShowUseCase::new();
+    /// let req = ShowUseCaseRequestDto { mode: "search".into(), target: "all".into(), scope: None };
+    /// assert!(uc.execute(req).is_err()); // "search" mode is not implemented
+    /// ```
     pub fn execute(
         &self,
         request: ShowUseCaseRequestDto,

--- a/src/use_case/show/show_use_case.rs
+++ b/src/use_case/show/show_use_case.rs
@@ -36,6 +36,18 @@ impl ShowUseCase {
     ) -> Result<ShowUseCaseResponseDto, Box<dyn std::error::Error>> {
         info!("Executing ShowUseCase with request: {:?}", request);
 
+        if request.mode == "search" {
+            return Err("show --mode search is not implemented yet".into());
+        }
+
+        if request.target == "group" {
+            return Err("show --target group is not implemented yet".into());
+        }
+
+        if request.scope.is_some() {
+            return Err("--scope is only supported with --mode search".into());
+        }
+
         let config = SpecTrailConfig::from_file("src/config/config.toml")?;
 
         let code_path = if request.target == "all" || request.target == "code" {


### PR DESCRIPTION
## Summary

This MR documents the smaller improvements that should be handled first for the `show` feature in `003`.

Rather than introducing large specification changes or new features, this MR focuses on clarifying the first set of low-risk, high-value improvements that are easy to start with.

## Included in This MR

- Document the plan to replace the raw `Debug` output in `show`
- Document the plan to remove `println!` from the library layer
- Document the temporary handling for unimplemented `search` and `group`
- Document the warning presentation cleanup points
- Document the temporary handling of `scope`

## Intent

- Lock down the lightweight improvement scope for `003` before starting the larger design work in `004` and later
- Incrementally improve CLI clarity and responsibility boundaries
- Reduce the mismatch between the specification and the implementation in a low-risk way

## Notes

- Larger changes such as scan-path redesign or parser fixes are intentionally out of scope for this MR
- The formal specification work for `filter`, `find`, and `trace` is expected to happen in `004` and later
