### PR TITLE
docs: define show command output architecture and view/format separation

### DIFF
--- a/specify_manual/command_design/show_annotattion/io.md
+++ b/specify_manual/command_design/show_annotattion/io.md
@@ -32,9 +32,11 @@ Returns a flat list of all annotations from both `src/` and `specify_manual/`.
 
 Returns a list of annotations filtered by source.
 
-### target: group (View: group)
+### view: group
 
-When `--view group` is specified, annotations are organized hierarchically by Layer and Type.
+When `--view group` is specified, the output is organized hierarchically by Layer and Type.
+This is a presentation choice applied on top of normal targets (`all`, `document`, `code`).
+It only applies when `--view group` is used.
 
 ```json
 {

--- a/specify_manual/command_design/show_annotattion/io.md
+++ b/specify_manual/command_design/show_annotattion/io.md
@@ -5,13 +5,12 @@ This command shows annotations for both source code and document.
 ## Input
 
 ```bash
-show --mode list --target all --config src/config/default.toml
-show --mode list --target all --config src/config/simple_sample.toml
-show --mode list --target all
-show --mode list --target document
-show --mode list --target code
-show --mode list --target group
-show --mode search --target code --scope src/
+show --target all --config src/config/default.toml --view list --format text
+show --target all --config src/config/simple_sample.toml --view detail
+show --target all --view summary
+show --target document
+show --target code
+show --target all --view group
 ```
 
 /// [@st-manual-io-show-config] layer: spec-detail, type: Convention, name: Show Config Selection
@@ -33,9 +32,9 @@ Returns a flat list of all annotations from both `src/` and `specify_manual/`.
 
 Returns a list of annotations filtered by source.
 
-### target: group
+### target: group (View: group)
 
-Returns annotations organized hierarchically by Layer and Type.
+When `--view group` is specified, annotations are organized hierarchically by Layer and Type.
 
 ```json
 {
@@ -56,12 +55,16 @@ It also makes it possible to switch between `config/default.toml` and `config/si
 
 ## Output
 
-The output can be provided in **Standard Output (Text)** or **JSON** format.
+The output is managed by the `Presentation` layer (`output` module) and can be controlled via `--view` and `--format` options.
 
-### Text Output (Standard)
+### View Options
 
-A human-readable list or tree, as shown in [UseCase examples](./use_case.md).
+- `summary`: Overall statistics (count, types, etc.).
+- `list`: File-based summary list (default).
+- `group`: Grouped by attributes (Layer, Type, etc.).
+- `detail`: Full annotation details.
 
-### JSON Output
+### Format Options
 
-A structured representation suitable for machine processing or the `report-ui`.
+- `text`: Human-readable text (Standard Output/Error).
+- `json`: Machine-readable structured representation.

--- a/specify_manual/command_design/show_annotattion/useage.md
+++ b/specify_manual/command_design/show_annotattion/useage.md
@@ -5,19 +5,19 @@ In this section, we describe about how to use the show-command.
 /// [@st-manual-usage-show-all] layer: spec-detail, type: Convention, name: Show All Annotations
 To show all annotations, choose the config that matches the application and scan both document and code roots:
 ```bash
-cargo run --bin show -- --mode list --target all --config src/config/default.toml
+cargo run --bin show -- --target all --config src/config/default.toml
 ```
 
 /// [@st-manual-usage-show-document] layer: spec-detail, type: Convention, name: Show Document Annotations
 To show only document annotations, use the config for the application and target documents:
 ```bash
-cargo run --bin show -- --mode list --target document --config src/config/simple_sample.toml
+cargo run --bin show -- --target document --config src/config/simple_sample.toml
 ```
 
 /// [@st-manual-usage-show-code] layer: spec-detail, type: Convention, name: Show Code Annotations
 To show only code annotations, use the config for the application and target code:
 ```bash
-cargo run --bin show -- --mode list --target code --config src/config/default.toml
+cargo run --bin show -- --target code --config src/config/default.toml
 ```
 
 /// [@st-manual-usage-show-search] layer: spec-detail, type: Convention, name: Search Annotations
@@ -27,7 +27,7 @@ cargo run --bin show -- --mode search --target all --scope "search_query" --conf
 ```
 
 /// [@st-manual-usage-show-group] layer: spec-detail, type: Convention, name: Show Grouped Annotations
-To show grouped annotations (future implementation):
+To show grouped annotations:
 ```bash
-cargo run --bin show -- --mode list --target group
+cargo run --bin show -- --view group
 ```

--- a/src/bin/show/dto.rs
+++ b/src/bin/show/dto.rs
@@ -232,7 +232,7 @@ impl ShowRequestDto {
             }
         }
 
-        let mode = mode.ok_or("--mode is required")?;
+        let mode = mode.unwrap_or(ShowMode::List);
         let target = target.ok_or("--target is required")?;
 
         let mut request = ShowRequestDto::new(mode, target)
@@ -314,10 +314,11 @@ mod tests {
     }
 
     #[test]
-    fn from_args_fails_when_mode_is_missing() {
+    fn from_args_defaults_mode_to_list_when_missing() {
         let result = ShowRequestDto::from_args(&args(&["show", "--target", "all"]));
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err().to_string(), "--mode is required");
+        assert!(result.is_ok());
+        let req = result.unwrap();
+        assert_eq!(req.mode, ShowMode::List);
     }
 
     #[test]
@@ -475,5 +476,33 @@ mod tests {
         assert_eq!(req.target, ShowTarget::All);
         assert_eq!(req.scope, Some("@st-test".to_string()));
         assert_eq!(req.config_path, Some("config/custom.toml".to_string()));
+    }
+
+    #[test]
+    fn from_args_fails_when_view_has_no_value() {
+        let result = ShowRequestDto::from_args(&args(&["show", "--mode", "list", "--target", "all", "--view"]));
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "--view requires a value");
+    }
+
+    #[test]
+    fn from_args_fails_with_invalid_view_value() {
+        let result = ShowRequestDto::from_args(&args(&["show", "--mode", "list", "--target", "all", "--view", "invalid"]));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Invalid view: invalid"));
+    }
+
+    #[test]
+    fn from_args_fails_when_format_has_no_value() {
+        let result = ShowRequestDto::from_args(&args(&["show", "--mode", "list", "--target", "all", "--format"]));
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().to_string(), "--format requires a value");
+    }
+
+    #[test]
+    fn from_args_fails_with_invalid_format_value() {
+        let result = ShowRequestDto::from_args(&args(&["show", "--mode", "list", "--target", "all", "--format", "invalid"]));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Invalid format: invalid"));
     }
 }

--- a/src/bin/show/dto.rs
+++ b/src/bin/show/dto.rs
@@ -6,14 +6,12 @@ use std::str::FromStr;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShowMode {
     List,
-    Search,
 }
 
 impl fmt::Display for ShowMode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ShowMode::List => write!(f, "list"),
-            ShowMode::Search => write!(f, "search"),
         }
     }
 }
@@ -24,8 +22,69 @@ impl std::str::FromStr for ShowMode {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "list" => Ok(ShowMode::List),
-            "search" => Ok(ShowMode::Search),
             _ => Err(format!("Invalid mode: {}", s)),
+        }
+    }
+}
+
+/// [@st-code-bin-show-dto-show-view] layer: abstract, type: Structure, name: ShowView
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShowView {
+    Summary,
+    List,
+    Group,
+    Detail,
+}
+
+impl fmt::Display for ShowView {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ShowView::Summary => write!(f, "summary"),
+            ShowView::List => write!(f, "list"),
+            ShowView::Group => write!(f, "group"),
+            ShowView::Detail => write!(f, "detail"),
+        }
+    }
+}
+
+impl std::str::FromStr for ShowView {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "summary" => Ok(ShowView::Summary),
+            "list" => Ok(ShowView::List),
+            "group" => Ok(ShowView::Group),
+            "detail" => Ok(ShowView::Detail),
+            _ => Err(format!("Invalid view: {}", s)),
+        }
+    }
+}
+
+/// [@st-code-bin-show-dto-show-format] layer: abstract, type: Structure, name: ShowFormat
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShowFormat {
+    Text,
+    Json,
+}
+
+impl fmt::Display for ShowFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ShowFormat::Text => write!(f, "text"),
+            ShowFormat::Json => write!(f, "json"),
+        }
+    }
+}
+
+impl std::str::FromStr for ShowFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "text" => Ok(ShowFormat::Text),
+            "json" => Ok(ShowFormat::Json),
+            _ => Err(format!("Invalid format: {}", s)),
         }
     }
 }
@@ -36,7 +95,6 @@ pub enum ShowTarget {
     All,
     Document,
     Code,
-    Group,
 }
 
 impl fmt::Display for ShowTarget {
@@ -45,7 +103,6 @@ impl fmt::Display for ShowTarget {
             ShowTarget::All => write!(f, "all"),
             ShowTarget::Document => write!(f, "document"),
             ShowTarget::Code => write!(f, "code"),
-            ShowTarget::Group => write!(f, "group"),
         }
     }
 }
@@ -58,7 +115,6 @@ impl std::str::FromStr for ShowTarget {
             "all" => Ok(ShowTarget::All),
             "document" => Ok(ShowTarget::Document),
             "code" => Ok(ShowTarget::Code),
-            "group" => Ok(ShowTarget::Group),
             _ => Err(format!("Invalid target: {}", s)),
         }
     }
@@ -69,6 +125,8 @@ impl std::str::FromStr for ShowTarget {
 pub struct ShowRequestDto {
     pub mode: ShowMode,
     pub target: ShowTarget,
+    pub view: ShowView,
+    pub format: ShowFormat,
     pub scope: Option<String>,
     /// [@st-code-bin-show-dto-show-request-dto-config-path] layer: abstract, type: Structure, name: config_path
     pub config_path: Option<String>,
@@ -79,9 +137,21 @@ impl ShowRequestDto {
         ShowRequestDto {
             mode,
             target,
+            view: ShowView::List,
+            format: ShowFormat::Text,
             scope: None,
             config_path: None,
         }
+    }
+
+    pub fn with_view(mut self, view: ShowView) -> Self {
+        self.view = view;
+        self
+    }
+
+    pub fn with_format(mut self, format: ShowFormat) -> Self {
+        self.format = format;
+        self
     }
 
     pub fn with_scope(mut self, scope: String) -> Self {
@@ -123,6 +193,8 @@ impl ShowRequestDto {
     pub fn from_args(args: &[String]) -> Result<Self, Box<dyn std::error::Error>> {
         let mut mode: Option<ShowMode> = None;
         let mut target: Option<ShowTarget> = None;
+        let mut view: ShowView = ShowView::List;
+        let mut format: ShowFormat = ShowFormat::Text;
         let mut scope: Option<String> = None;
         let mut config_path: Option<String> = None;
 
@@ -140,6 +212,16 @@ impl ShowRequestDto {
                         &args.next().ok_or("--target requires a value")?
                     )?);
                 }
+                "--view" => {
+                    view = ShowView::from_str(
+                        &args.next().ok_or("--view requires a value")?
+                    )?;
+                }
+                "--format" => {
+                    format = ShowFormat::from_str(
+                        &args.next().ok_or("--format requires a value")?
+                    )?;
+                }
                 "--scope" => {
                     scope = Some(args.next().ok_or("--scope requires a value")?.to_string());
                 }
@@ -153,19 +235,9 @@ impl ShowRequestDto {
         let mode = mode.ok_or("--mode is required")?;
         let target = target.ok_or("--target is required")?;
 
-        if target == ShowTarget::Group {
-            return Err("--target group is not implemented yet".into());
-        }
-
-        if mode == ShowMode::Search && scope.is_none() {
-            return Err("--scope is required with --mode search".into());
-        }
-
-        if mode != ShowMode::Search && scope.is_some() {
-            return Err("--scope is only supported with --mode search".into());
-        }
-
-        let mut request = ShowRequestDto::new(mode, target);
+        let mut request = ShowRequestDto::new(mode, target)
+            .with_view(view)
+            .with_format(format);
         if let Some(s) = scope {
             request = request.with_scope(s);
         }
@@ -195,63 +267,34 @@ mod tests {
     }
 
     #[test]
-    fn rejects_group_target_until_it_is_implemented() {
-        let result = ShowRequestDto::from_args(&args(&["show", "--mode", "list", "--target", "group"]));
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "--target group is not implemented yet"
-        );
+    fn from_args_defaults_view_to_list_and_format_to_text() {
+        let result = ShowRequestDto::from_args(&args(&["show", "--mode", "list", "--target", "all"]));
+        assert!(result.is_ok());
+        let req = result.unwrap();
+        assert_eq!(req.mode, ShowMode::List);
+        assert_eq!(req.target, ShowTarget::All);
+        assert_eq!(req.view, ShowView::List);
+        assert_eq!(req.format, ShowFormat::Text);
+        assert!(req.scope.is_none());
     }
 
     #[test]
-    fn rejects_scope_without_search_mode() {
+    fn from_args_succeeds_with_view_and_format() {
         let result = ShowRequestDto::from_args(&args(&[
             "show",
             "--mode",
             "list",
             "--target",
             "all",
-            "--scope",
-            "@st-foo",
-        ]));
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "--scope is only supported with --mode search"
-        );
-    }
-
-    #[test]
-    fn requires_scope_for_search_mode() {
-        let result = ShowRequestDto::from_args(&args(&["show", "--mode", "search", "--target", "all"]));
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "--scope is required with --mode search"
-        );
-    }
-
-    #[test]
-    fn from_args_succeeds_with_list_mode_and_all_target() {
-        let result = ShowRequestDto::from_args(&args(&["show", "--mode", "list", "--target", "all"]));
-        assert!(result.is_ok());
-        let req = result.unwrap();
-        assert_eq!(req.mode, ShowMode::List);
-        assert_eq!(req.target, ShowTarget::All);
-        assert!(req.scope.is_none());
-    }
-
-    #[test]
-    fn from_args_succeeds_with_search_mode_and_scope() {
-        let result = ShowRequestDto::from_args(&args(&[
-            "show", "--mode", "search", "--target", "all", "--scope", "@st-foo",
+            "--view",
+            "detail",
+            "--format",
+            "json",
         ]));
         assert!(result.is_ok());
         let req = result.unwrap();
-        assert_eq!(req.mode, ShowMode::Search);
-        assert_eq!(req.target, ShowTarget::All);
-        assert_eq!(req.scope, Some("@st-foo".to_string()));
+        assert_eq!(req.view, ShowView::Detail);
+        assert_eq!(req.format, ShowFormat::Json);
     }
 
     #[test]
@@ -299,15 +342,6 @@ mod tests {
     }
 
     #[test]
-    fn from_args_fails_when_scope_has_no_value() {
-        let result = ShowRequestDto::from_args(&args(&[
-            "show", "--mode", "search", "--target", "all", "--scope",
-        ]));
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err().to_string(), "--scope requires a value");
-    }
-
-    #[test]
     fn from_args_fails_with_unknown_argument() {
         let result = ShowRequestDto::from_args(&args(&[
             "show", "--mode", "list", "--target", "all", "--unknown",
@@ -335,10 +369,6 @@ mod tests {
         assert_eq!(ShowMode::List.to_string(), "list");
     }
 
-    #[test]
-    fn show_mode_displays_search() {
-        assert_eq!(ShowMode::Search.to_string(), "search");
-    }
 
     #[test]
     fn show_target_displays_all() {
@@ -355,10 +385,6 @@ mod tests {
         assert_eq!(ShowTarget::Code.to_string(), "code");
     }
 
-    #[test]
-    fn show_target_displays_group() {
-        assert_eq!(ShowTarget::Group.to_string(), "group");
-    }
 
     #[test]
     fn show_request_dto_new_has_no_scope() {
@@ -370,7 +396,7 @@ mod tests {
 
     #[test]
     fn show_request_dto_with_scope_sets_scope() {
-        let req = ShowRequestDto::new(ShowMode::Search, ShowTarget::All)
+        let req = ShowRequestDto::new(ShowMode::List, ShowTarget::All)
             .with_scope("@st-bar".to_string());
         assert_eq!(req.scope, Some("@st-bar".to_string()));
     }
@@ -380,10 +406,6 @@ mod tests {
         assert_eq!("list".parse::<ShowMode>().unwrap(), ShowMode::List);
     }
 
-    #[test]
-    fn show_mode_from_str_parses_search() {
-        assert_eq!("search".parse::<ShowMode>().unwrap(), ShowMode::Search);
-    }
 
     #[test]
     fn show_mode_from_str_rejects_unknown() {
@@ -395,7 +417,6 @@ mod tests {
         assert_eq!("all".parse::<ShowTarget>().unwrap(), ShowTarget::All);
         assert_eq!("document".parse::<ShowTarget>().unwrap(), ShowTarget::Document);
         assert_eq!("code".parse::<ShowTarget>().unwrap(), ShowTarget::Code);
-        assert_eq!("group".parse::<ShowTarget>().unwrap(), ShowTarget::Group);
     }
 
     #[test]
@@ -440,7 +461,7 @@ mod tests {
         let result = ShowRequestDto::from_args(&args(&[
             "show",
             "--mode",
-            "search",
+            "list",
             "--target",
             "all",
             "--scope",
@@ -450,7 +471,7 @@ mod tests {
         ]));
         assert!(result.is_ok());
         let req = result.unwrap();
-        assert_eq!(req.mode, ShowMode::Search);
+        assert_eq!(req.mode, ShowMode::List);
         assert_eq!(req.target, ShowTarget::All);
         assert_eq!(req.scope, Some("@st-test".to_string()));
         assert_eq!(req.config_path, Some("config/custom.toml".to_string()));

--- a/src/bin/show/main.rs
+++ b/src/bin/show/main.rs
@@ -29,7 +29,7 @@ fn main() {
 
     match response {
         Ok(response) => {
-            let view_model = adapt_response(&response, request_dto.view, request_dto.format);
+            let view_model = adapt_response(response, request_dto.view, request_dto.format);
             output::render(&view_model);
         }
         Err(error) => {
@@ -38,4 +38,3 @@ fn main() {
         }
     }
 }
-

--- a/src/bin/show/main.rs
+++ b/src/bin/show/main.rs
@@ -2,6 +2,7 @@
 mod dto;
 mod show_request_adapter;
 mod show_response_adapter;
+mod output;
 
 use dto::ShowRequestDto;
 use show_request_adapter::adapt_request;
@@ -28,13 +29,8 @@ fn main() {
 
     match response {
         Ok(response) => {
-            let view = adapt_response(&response);
-            for line in view.stdout {
-                println!("{}", line);
-            }
-            for line in view.stderr {
-                eprintln!("{}", line);
-            }
+            let view_model = adapt_response(&response, request_dto.view, request_dto.format);
+            output::render(&view_model);
         }
         Err(error) => {
             eprintln!("Error: {}", error);

--- a/src/bin/show/main.rs
+++ b/src/bin/show/main.rs
@@ -1,24 +1,16 @@
 /// [@st-code-bin-show-main-file] layer: abstract, type: File, name: main.rs
 mod dto;
+mod show_request_adapter;
+mod show_response_adapter;
 
-use SpecTrail::domains::models::annotation::code_annotation::CodeAnnotation;
-use SpecTrail::domains::models::annotation::document_annotation::DocumentAnnotation;
-use SpecTrail::domains::services::annotation::scanner::ScanWarning;
-use SpecTrail::use_case::show::show_use_case::{
-    ShowUseCase, ShowUseCaseRequestDto, ShowUseCaseResponseDto,
-};
 use dto::ShowRequestDto;
+use show_request_adapter::adapt_request;
+use show_response_adapter::adapt_response;
+use SpecTrail::use_case::show::show_use_case::ShowUseCase;
 use std::env;
 use std::process;
 
 /// Entry point for the `show` CLI: parses command-line arguments, executes the Show use case, and prints any warnings and a compact summary of results.
-///
-/// # Examples
-///
-/// ```no_run
-/// // Run the compiled binary from a shell:
-/// // cargo run --bin show -- <mode> <target> [scope]
-/// ```
 fn main() {
     env_logger::init();
     let args: Vec<String> = env::args().collect();
@@ -31,22 +23,18 @@ fn main() {
         }
     };
 
-    /* Convert to UseCase Request DTO */
-    let use_case_request = ShowUseCaseRequestDto {
-        mode: request_dto.mode.to_string(),
-        target: request_dto.target.to_string(),
-        scope: request_dto.scope.clone(),
-        config_path: request_dto.config_path.clone(),
-    };
-
-    let use_case: ShowUseCase = ShowUseCase::new();
-    let response: Result<ShowUseCaseResponseDto, Box<dyn std::error::Error>> =
-        use_case.execute(use_case_request);
+    let use_case = ShowUseCase::new();
+    let response = use_case.execute(adapt_request(&request_dto));
 
     match response {
         Ok(response) => {
-            print_warnings(&response.warnings);
-            print_response_summary(&response);
+            let view = adapt_response(&response);
+            for line in view.stdout {
+                println!("{}", line);
+            }
+            for line in view.stderr {
+                eprintln!("{}", line);
+            }
         }
         Err(error) => {
             eprintln!("Error: {}", error);
@@ -55,240 +43,3 @@ fn main() {
     }
 }
 
-/// Prints scan warnings to standard error in a human-readable form.
-///
-/// Parse warnings are printed as:
-/// `WARNING [parse] <source_file>: <message> (raw: '<raw_text>')`
-/// Resolve warnings are printed as:
-/// `WARNING [resolve] <message>`
-///
-/// # Arguments
-///
-/// * `warnings` - Slice of `ScanWarning` values to print.
-///
-/// # Examples
-///
-/// ```
-/// // Assuming `ScanWarning` is in scope:
-/// // print_warnings(&[] as &[crate::ScanWarning]);
-/// print_warnings(&[]);
-/// ```
-fn print_warnings(warnings: &[ScanWarning]) {
-    for warning in warnings {
-        match warning {
-            ScanWarning::Parse(pw) => {
-                eprintln!(
-                    "WARNING [parse] {}: {} (raw: '{}')",
-                    pw.source_file, pw.message, pw.raw_text
-                );
-            }
-            ScanWarning::Resolve(rw) => {
-                eprintln!("WARNING [resolve] {}", rw.message);
-            }
-        }
-    }
-}
-
-/// Prints a compact summary of the show use-case response counts to stdout.
-///
-/// The summary includes counts of code files, code annotations, document files,
-/// document annotations, and total warnings from the provided response.
-///
-/// # Examples
-///
-/// ```
-/// // Construct a minimal response with empty collections (types assumed in scope).
-/// let response = ShowUseCaseResponseDto {
-///     code_annotations: Vec::new(),
-///     document_annotations: Vec::new(),
-///     warnings: Vec::new(),
-/// };
-/// print_response_summary(&response);
-/// ```
-fn print_response_summary(response: &ShowUseCaseResponseDto) {
-    let code_totals = count_code_annotations(&response.code_annotations);
-    let document_totals = count_document_annotations(&response.document_annotations);
-
-    println!("Show summary");
-    println!("  code files: {}", response.code_annotations.len());
-    println!("  code annotations: {}", code_totals);
-    println!("  document files: {}", response.document_annotations.len());
-    println!("  document annotations: {}", document_totals);
-    println!("  warnings: {}", response.warnings.len());
-}
-
-/// Counts the total number of annotations contained in the given code-file annotations.
-///
-/// The count is the sum, for each `CodeAnnotation`, of its `metas`, `abstracts`,
-/// `details`, and `implementations` collections.
-///
-/// # Examples
-///
-/// ```
-/// // Assuming CodeAnnotation has a simple constructor for tests; replace with
-/// // real constructors in actual code.
-/// use spec_trail_domain::CodeAnnotation;
-///
-/// let annotations: Vec<CodeAnnotation> = vec![];
-/// assert_eq!(crate::count_code_annotations(&annotations), 0);
-/// ```
-fn count_code_annotations(annotations: &[CodeAnnotation]) -> usize {
-    annotations
-        .iter()
-        .map(|annotation| {
-            annotation.metas.len()
-                + annotation.abstracts.len()
-                + annotation.details.len()
-                + annotation.implementations.len()
-        })
-        .sum()
-}
-
-/// Counts all annotations contained in the given document annotations slice.
-///
-/// Returns the total number of `metas`, `abstracts`, `details`, and `implementations` across every `DocumentAnnotation` in `annotations`.
-///
-/// # Returns
-///
-/// `usize` total count of document-level annotation items.
-fn count_document_annotations(annotations: &[DocumentAnnotation]) -> usize {
-    annotations
-        .iter()
-        .map(|annotation| {
-            annotation.metas.len()
-                + annotation.abstracts.len()
-                + annotation.details.len()
-                + annotation.implementations.len()
-        })
-        .sum()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use SpecTrail::domains::models::abstract_annotation::{
-        AbstractAnnotation, AbstractAnnotationId, AbstractName,
-    };
-    use SpecTrail::domains::models::implementation::{
-        ImplementationAnnotation, ImplementationAnnotationId, ImplementationArtifact,
-        ImplementationSpecName,
-    };
-    use SpecTrail::domains::models::layer::Layer;
-    use SpecTrail::domains::models::meta::{MetaAnnotation, MetaAnnotationId, MetaName};
-    use SpecTrail::domains::models::spec_detail::{
-        SpecDetailAnnotation, SpecDetailAnnotationId, SpecDetailName,
-    };
-
-    fn make_meta() -> MetaAnnotation {
-        MetaAnnotation {
-            id: MetaAnnotationId("m".to_string()),
-            name: MetaName("Meta".to_string()),
-            r#type: None,
-            layer: Layer::Meta,
-            links: vec![],
-        }
-    }
-
-    fn make_abstract() -> AbstractAnnotation {
-        AbstractAnnotation {
-            id: AbstractAnnotationId("a".to_string()),
-            name: AbstractName("Abstract".to_string()),
-            r#type: None,
-            layer: Layer::Abstract,
-            links: vec![],
-        }
-    }
-
-    fn make_detail() -> SpecDetailAnnotation {
-        SpecDetailAnnotation {
-            id: SpecDetailAnnotationId("d".to_string()),
-            name: SpecDetailName("Detail".to_string()),
-            r#type: None,
-            layer: Layer::SpecDetail,
-            links: vec![],
-        }
-    }
-
-    fn make_implementation() -> ImplementationAnnotation {
-        ImplementationAnnotation {
-            id: ImplementationAnnotationId("i".to_string()),
-            name: ImplementationSpecName("Impl".to_string()),
-            r#type: None,
-            layer: Layer::Implementation,
-            links: vec![],
-            artifact: ImplementationArtifact("artifact".to_string()),
-            status: None,
-        }
-    }
-
-    fn make_code_annotation(
-        metas: usize,
-        abstracts: usize,
-        details: usize,
-        impls: usize,
-    ) -> CodeAnnotation {
-        CodeAnnotation {
-            metas: (0..metas).map(|_| make_meta()).collect(),
-            abstracts: (0..abstracts).map(|_| make_abstract()).collect(),
-            details: (0..details).map(|_| make_detail()).collect(),
-            implementations: (0..impls).map(|_| make_implementation()).collect(),
-        }
-    }
-
-    fn make_document_annotation(
-        metas: usize,
-        abstracts: usize,
-        details: usize,
-        impls: usize,
-    ) -> DocumentAnnotation {
-        DocumentAnnotation {
-            metas: (0..metas).map(|_| make_meta()).collect(),
-            abstracts: (0..abstracts).map(|_| make_abstract()).collect(),
-            details: (0..details).map(|_| make_detail()).collect(),
-            implementations: (0..impls).map(|_| make_implementation()).collect(),
-        }
-    }
-
-    #[test]
-    fn count_code_annotations_returns_zero_for_empty_slice() {
-        assert_eq!(count_code_annotations(&[]), 0);
-    }
-
-    #[test]
-    fn count_code_annotations_sums_all_annotation_types() {
-        let annotation = make_code_annotation(2, 3, 1, 4);
-        assert_eq!(count_code_annotations(&[annotation]), 10);
-    }
-
-    #[test]
-    fn count_code_annotations_sums_across_multiple_files() {
-        let a = make_code_annotation(1, 0, 0, 0);
-        let b = make_code_annotation(0, 2, 1, 0);
-        let c = make_code_annotation(0, 0, 0, 3);
-        assert_eq!(count_code_annotations(&[a, b, c]), 7);
-    }
-
-    #[test]
-    fn count_code_annotations_with_all_empty_collections_returns_zero() {
-        let annotation = make_code_annotation(0, 0, 0, 0);
-        assert_eq!(count_code_annotations(&[annotation]), 0);
-    }
-
-    #[test]
-    fn count_document_annotations_returns_zero_for_empty_slice() {
-        assert_eq!(count_document_annotations(&[]), 0);
-    }
-
-    #[test]
-    fn count_document_annotations_sums_all_annotation_types() {
-        let annotation = make_document_annotation(1, 2, 3, 4);
-        assert_eq!(count_document_annotations(&[annotation]), 10);
-    }
-
-    #[test]
-    fn count_document_annotations_sums_across_multiple_files() {
-        let a = make_document_annotation(2, 0, 0, 0);
-        let b = make_document_annotation(0, 0, 3, 0);
-        assert_eq!(count_document_annotations(&[a, b]), 5);
-    }
-}

--- a/src/bin/show/show_request_adapter.rs
+++ b/src/bin/show/show_request_adapter.rs
@@ -1,0 +1,46 @@
+use crate::dto::ShowRequestDto;
+use SpecTrail::use_case::show::show_use_case::ShowUseCaseRequestDto;
+
+pub fn adapt_request(request: &ShowRequestDto) -> ShowUseCaseRequestDto {
+    ShowUseCaseRequestDto {
+        mode: request.mode.to_string(),
+        target: request.target.to_string(),
+        scope: request.scope.clone(),
+        config_path: request.config_path.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dto::{ShowMode, ShowRequestDto, ShowTarget};
+
+    #[test]
+    fn adapts_list_request_without_optional_fields() {
+        let request = ShowRequestDto::new(ShowMode::List, ShowTarget::All);
+
+        let adapted = adapt_request(&request);
+
+        assert_eq!(adapted.mode, "list");
+        assert_eq!(adapted.target, "all");
+        assert_eq!(adapted.scope, None);
+        assert_eq!(adapted.config_path, None);
+    }
+
+    #[test]
+    fn preserves_scope_and_config_path() {
+        let request = ShowRequestDto::new(ShowMode::Search, ShowTarget::Document)
+            .with_scope("@st-foo".to_string())
+            .with_config_path("src/config/config.toml".to_string());
+
+        let adapted = adapt_request(&request);
+
+        assert_eq!(adapted.mode, "search");
+        assert_eq!(adapted.target, "document");
+        assert_eq!(adapted.scope, Some("@st-foo".to_string()));
+        assert_eq!(
+            adapted.config_path,
+            Some("src/config/config.toml".to_string())
+        );
+    }
+}

--- a/src/bin/show/show_request_adapter.rs
+++ b/src/bin/show/show_request_adapter.rs
@@ -26,21 +26,4 @@ mod tests {
         assert_eq!(adapted.scope, None);
         assert_eq!(adapted.config_path, None);
     }
-
-    #[test]
-    fn preserves_scope_and_config_path() {
-        let request = ShowRequestDto::new(ShowMode::Search, ShowTarget::Document)
-            .with_scope("@st-foo".to_string())
-            .with_config_path("src/config/config.toml".to_string());
-
-        let adapted = adapt_request(&request);
-
-        assert_eq!(adapted.mode, "search");
-        assert_eq!(adapted.target, "document");
-        assert_eq!(adapted.scope, Some("@st-foo".to_string()));
-        assert_eq!(
-            adapted.config_path,
-            Some("src/config/config.toml".to_string())
-        );
-    }
 }

--- a/src/bin/show/show_response_adapter.rs
+++ b/src/bin/show/show_response_adapter.rs
@@ -1,0 +1,288 @@
+use SpecTrail::domains::models::annotation::code_annotation::CodeAnnotation;
+use SpecTrail::domains::models::annotation::document_annotation::DocumentAnnotation;
+use SpecTrail::domains::services::annotation::scanner::ScanWarning;
+use SpecTrail::use_case::show::show_use_case::ShowUseCaseResponseDto;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ShowResponseView {
+    pub stdout: Vec<String>,
+    pub stderr: Vec<String>,
+}
+
+pub fn adapt_response(response: &ShowUseCaseResponseDto) -> ShowResponseView {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+
+    let code_annotations = count_code_annotations(&response.code_annotations);
+    let document_annotations = count_document_annotations(&response.document_annotations);
+    let total_annotations = code_annotations + document_annotations;
+
+    stdout.push(format!("Found {} annotations", total_annotations));
+    stdout.push(format!("Warnings: {}", response.warnings.len()));
+    stdout.push(String::new());
+
+    append_file_section(&mut stdout, &response.document_annotations, "document");
+    append_file_section(&mut stdout, &response.code_annotations, "code");
+
+    for warning in &response.warnings {
+        stderr.push(format_warning(warning));
+    }
+
+    ShowResponseView { stdout, stderr }
+}
+
+fn append_file_section(stdout: &mut Vec<String>, annotations: &[impl AnnotationGroupView], label: &str) {
+    let mut items: Vec<_> = annotations.iter().collect();
+    items.sort_by(|a, b| a.source_file().cmp(b.source_file()));
+
+    for (index, annotation) in items.into_iter().enumerate() {
+        stdout.push(format!(
+            "[{}] {}",
+            index + 1,
+            annotation.source_file()
+        ));
+        stdout.push(format!(
+            "    metas: {}",
+            annotation.meta_count()
+        ));
+        stdout.push(format!(
+            "    abstracts: {}",
+            annotation.abstract_count()
+        ));
+        stdout.push(format!(
+            "    details: {}",
+            annotation.detail_count()
+        ));
+        stdout.push(format!(
+            "    implementations: {}",
+            annotation.implementation_count()
+        ));
+        stdout.push(format!("    source: {}", label));
+        stdout.push(String::new());
+    }
+}
+
+fn format_warning(warning: &ScanWarning) -> String {
+    match warning {
+        ScanWarning::Parse(pw) => format!(
+            "warning: skipped unknown annotation at {}:{}",
+            pw.source_file, pw.line
+        ),
+        ScanWarning::Resolve(rw) => format!("warning: {}", rw.message),
+    }
+}
+
+fn count_code_annotations(annotations: &[CodeAnnotation]) -> usize {
+    annotations
+        .iter()
+        .map(|annotation| {
+            annotation.metas.len()
+                + annotation.abstracts.len()
+                + annotation.details.len()
+                + annotation.implementations.len()
+        })
+        .sum()
+}
+
+fn count_document_annotations(annotations: &[DocumentAnnotation]) -> usize {
+    annotations
+        .iter()
+        .map(|annotation| {
+            annotation.metas.len()
+                + annotation.abstracts.len()
+                + annotation.details.len()
+                + annotation.implementations.len()
+        })
+        .sum()
+}
+
+trait AnnotationGroupView {
+    fn source_file(&self) -> &str;
+    fn meta_count(&self) -> usize;
+    fn abstract_count(&self) -> usize;
+    fn detail_count(&self) -> usize;
+    fn implementation_count(&self) -> usize;
+}
+
+impl AnnotationGroupView for CodeAnnotation {
+    fn source_file(&self) -> &str {
+        &self.source_file
+    }
+
+    fn meta_count(&self) -> usize {
+        self.metas.len()
+    }
+
+    fn abstract_count(&self) -> usize {
+        self.abstracts.len()
+    }
+
+    fn detail_count(&self) -> usize {
+        self.details.len()
+    }
+
+    fn implementation_count(&self) -> usize {
+        self.implementations.len()
+    }
+}
+
+impl AnnotationGroupView for DocumentAnnotation {
+    fn source_file(&self) -> &str {
+        &self.source_file
+    }
+
+    fn meta_count(&self) -> usize {
+        self.metas.len()
+    }
+
+    fn abstract_count(&self) -> usize {
+        self.abstracts.len()
+    }
+
+    fn detail_count(&self) -> usize {
+        self.details.len()
+    }
+
+    fn implementation_count(&self) -> usize {
+        self.implementations.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use SpecTrail::domains::models::abstract_annotation::{
+        AbstractAnnotation, AbstractAnnotationId, AbstractName,
+    };
+    use SpecTrail::domains::models::implementation::{
+        ImplementationAnnotation, ImplementationArtifact, ImplementationLink,
+        ImplementationSpecName,
+    };
+    use SpecTrail::domains::models::layer::Layer;
+    use SpecTrail::domains::models::meta::{MetaAnnotation, MetaAnnotationId, MetaName};
+    use SpecTrail::domains::models::spec_detail::{
+        SpecDetailAnnotation, SpecDetailAnnotationId, SpecDetailLink, SpecDetailName,
+    };
+    use SpecTrail::domains::services::annotation::parser::ParseWarning;
+    use SpecTrail::domains::services::annotation::resolver::ResolveWarning;
+
+    fn make_meta() -> MetaAnnotation {
+        MetaAnnotation {
+            id: MetaAnnotationId("m".to_string()),
+            name: MetaName("Meta".to_string()),
+            r#type: None,
+            layer: Layer::Meta,
+            links: vec![],
+        }
+    }
+
+    fn make_abstract() -> AbstractAnnotation {
+        AbstractAnnotation {
+            id: AbstractAnnotationId("a".to_string()),
+            name: AbstractName("Abstract".to_string()),
+            r#type: None,
+            layer: Layer::Abstract,
+            links: vec![],
+        }
+    }
+
+    fn make_detail() -> SpecDetailAnnotation {
+        SpecDetailAnnotation {
+            id: SpecDetailAnnotationId("d".to_string()),
+            name: SpecDetailName("Detail".to_string()),
+            r#type: None,
+            layer: Layer::SpecDetail,
+            links: vec![SpecDetailLink::Abstract(Box::new(make_abstract()))],
+        }
+    }
+
+    fn make_implementation() -> ImplementationAnnotation {
+        ImplementationAnnotation {
+            id: SpecTrail::domains::models::implementation::ImplementationAnnotationId(
+                "i".to_string(),
+            ),
+            name: ImplementationSpecName("Impl".to_string()),
+            r#type: None,
+            layer: Layer::Implementation,
+            links: vec![ImplementationLink::Abstract(Box::new(make_abstract()))],
+            artifact: ImplementationArtifact("artifact".to_string()),
+            status: None,
+        }
+    }
+
+    #[test]
+    fn renders_summary_and_file_sections_into_stdout_lines() {
+        let response = ShowUseCaseResponseDto {
+            document_annotations: vec![DocumentAnnotation {
+                source_file: "docs/a.md".to_string(),
+                metas: vec![make_meta()],
+                abstracts: vec![make_abstract()],
+                details: vec![make_detail()],
+                implementations: vec![make_implementation()],
+            }],
+            code_annotations: vec![CodeAnnotation {
+                source_file: "src/a.rs".to_string(),
+                metas: vec![make_meta()],
+                abstracts: vec![make_abstract()],
+                details: vec![make_detail()],
+                implementations: vec![make_implementation()],
+            }],
+            warnings: vec![],
+        };
+
+        let view = adapt_response(&response);
+
+        assert_eq!(
+            view.stdout,
+            vec![
+                "Found 8 annotations".to_string(),
+                "Warnings: 0".to_string(),
+                "".to_string(),
+                "[1] docs/a.md".to_string(),
+                "    metas: 1".to_string(),
+                "    abstracts: 1".to_string(),
+                "    details: 1".to_string(),
+                "    implementations: 1".to_string(),
+                "    source: document".to_string(),
+                "".to_string(),
+                "[1] src/a.rs".to_string(),
+                "    metas: 1".to_string(),
+                "    abstracts: 1".to_string(),
+                "    details: 1".to_string(),
+                "    implementations: 1".to_string(),
+                "    source: code".to_string(),
+                "".to_string(),
+            ]
+        );
+        assert!(view.stderr.is_empty());
+    }
+
+    #[test]
+    fn separates_warning_lines_into_stderr() {
+        let response = ShowUseCaseResponseDto {
+            document_annotations: vec![],
+            code_annotations: vec![],
+            warnings: vec![
+                ScanWarning::Parse(ParseWarning {
+                    source_file: "src/main.rs".to_string(),
+                    line: 12,
+                    message: "broken".to_string(),
+                    raw_text: "@bad".to_string(),
+                }),
+                ScanWarning::Resolve(ResolveWarning {
+                    source_annotation_id: "x".to_string(),
+                    message: "missing link".to_string(),
+                }),
+            ],
+        };
+
+        let view = adapt_response(&response);
+
+        assert_eq!(view.stderr.len(), 2);
+        assert_eq!(
+            view.stderr[0],
+            "warning: skipped unknown annotation at src/main.rs:12".to_string()
+        );
+        assert_eq!(view.stderr[1], "warning: missing link".to_string());
+    }
+}

--- a/src/bin/show/show_response_adapter.rs
+++ b/src/bin/show/show_response_adapter.rs
@@ -13,14 +13,14 @@ pub struct ShowResponseView {
 }
 
 pub fn adapt_response(
-    response: &ShowUseCaseResponseDto,
+    response: ShowUseCaseResponseDto,
     view: crate::dto::ShowView,
     format: crate::dto::ShowFormat,
 ) -> ShowResponseView {
     ShowResponseView {
-        document_annotations: response.document_annotations.clone(),
-        code_annotations: response.code_annotations.clone(),
-        warnings: response.warnings.clone(),
+        document_annotations: response.document_annotations,
+        code_annotations: response.code_annotations,
+        warnings: response.warnings,
         view,
         format,
     }
@@ -109,7 +109,7 @@ mod tests {
         };
 
         let view = adapt_response(
-            &response,
+            response,
             crate::dto::ShowView::List,
             crate::dto::ShowFormat::Text,
         );
@@ -135,7 +135,7 @@ mod tests {
         };
 
         let view = adapt_response(
-            &response,
+            response,
             crate::dto::ShowView::Summary,
             crate::dto::ShowFormat::Json,
         );

--- a/src/bin/show/show_response_adapter.rs
+++ b/src/bin/show/show_response_adapter.rs
@@ -3,148 +3,26 @@ use SpecTrail::domains::models::annotation::document_annotation::DocumentAnnotat
 use SpecTrail::domains::services::annotation::scanner::ScanWarning;
 use SpecTrail::use_case::show::show_use_case::ShowUseCaseResponseDto;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct ShowResponseView {
-    pub stdout: Vec<String>,
-    pub stderr: Vec<String>,
+    pub document_annotations: Vec<DocumentAnnotation>,
+    pub code_annotations: Vec<CodeAnnotation>,
+    pub warnings: Vec<ScanWarning>,
+    pub view: crate::dto::ShowView,
+    pub format: crate::dto::ShowFormat,
 }
 
-pub fn adapt_response(response: &ShowUseCaseResponseDto) -> ShowResponseView {
-    let mut stdout = Vec::new();
-    let mut stderr = Vec::new();
-
-    let code_annotations = count_code_annotations(&response.code_annotations);
-    let document_annotations = count_document_annotations(&response.document_annotations);
-    let total_annotations = code_annotations + document_annotations;
-
-    stdout.push(format!("Found {} annotations", total_annotations));
-    stdout.push(format!("Warnings: {}", response.warnings.len()));
-    stdout.push(String::new());
-
-    append_file_section(&mut stdout, &response.document_annotations, "document");
-    append_file_section(&mut stdout, &response.code_annotations, "code");
-
-    for warning in &response.warnings {
-        stderr.push(format_warning(warning));
-    }
-
-    ShowResponseView { stdout, stderr }
-}
-
-fn append_file_section(stdout: &mut Vec<String>, annotations: &[impl AnnotationGroupView], label: &str) {
-    let mut items: Vec<_> = annotations.iter().collect();
-    items.sort_by(|a, b| a.source_file().cmp(b.source_file()));
-
-    for (index, annotation) in items.into_iter().enumerate() {
-        stdout.push(format!(
-            "[{}] {}",
-            index + 1,
-            annotation.source_file()
-        ));
-        stdout.push(format!(
-            "    metas: {}",
-            annotation.meta_count()
-        ));
-        stdout.push(format!(
-            "    abstracts: {}",
-            annotation.abstract_count()
-        ));
-        stdout.push(format!(
-            "    details: {}",
-            annotation.detail_count()
-        ));
-        stdout.push(format!(
-            "    implementations: {}",
-            annotation.implementation_count()
-        ));
-        stdout.push(format!("    source: {}", label));
-        stdout.push(String::new());
-    }
-}
-
-fn format_warning(warning: &ScanWarning) -> String {
-    match warning {
-        ScanWarning::Parse(pw) => format!(
-            "warning: skipped unknown annotation at {}:{}",
-            pw.source_file, pw.line
-        ),
-        ScanWarning::Resolve(rw) => format!("warning: {}", rw.message),
-    }
-}
-
-fn count_code_annotations(annotations: &[CodeAnnotation]) -> usize {
-    annotations
-        .iter()
-        .map(|annotation| {
-            annotation.metas.len()
-                + annotation.abstracts.len()
-                + annotation.details.len()
-                + annotation.implementations.len()
-        })
-        .sum()
-}
-
-fn count_document_annotations(annotations: &[DocumentAnnotation]) -> usize {
-    annotations
-        .iter()
-        .map(|annotation| {
-            annotation.metas.len()
-                + annotation.abstracts.len()
-                + annotation.details.len()
-                + annotation.implementations.len()
-        })
-        .sum()
-}
-
-trait AnnotationGroupView {
-    fn source_file(&self) -> &str;
-    fn meta_count(&self) -> usize;
-    fn abstract_count(&self) -> usize;
-    fn detail_count(&self) -> usize;
-    fn implementation_count(&self) -> usize;
-}
-
-impl AnnotationGroupView for CodeAnnotation {
-    fn source_file(&self) -> &str {
-        &self.source_file
-    }
-
-    fn meta_count(&self) -> usize {
-        self.metas.len()
-    }
-
-    fn abstract_count(&self) -> usize {
-        self.abstracts.len()
-    }
-
-    fn detail_count(&self) -> usize {
-        self.details.len()
-    }
-
-    fn implementation_count(&self) -> usize {
-        self.implementations.len()
-    }
-}
-
-impl AnnotationGroupView for DocumentAnnotation {
-    fn source_file(&self) -> &str {
-        &self.source_file
-    }
-
-    fn meta_count(&self) -> usize {
-        self.metas.len()
-    }
-
-    fn abstract_count(&self) -> usize {
-        self.abstracts.len()
-    }
-
-    fn detail_count(&self) -> usize {
-        self.details.len()
-    }
-
-    fn implementation_count(&self) -> usize {
-        self.implementations.len()
+pub fn adapt_response(
+    response: &ShowUseCaseResponseDto,
+    view: crate::dto::ShowView,
+    format: crate::dto::ShowFormat,
+) -> ShowResponseView {
+    ShowResponseView {
+        document_annotations: response.document_annotations.clone(),
+        code_annotations: response.code_annotations.clone(),
+        warnings: response.warnings.clone(),
+        view,
+        format,
     }
 }
 
@@ -211,7 +89,7 @@ mod tests {
     }
 
     #[test]
-    fn renders_summary_and_file_sections_into_stdout_lines() {
+    fn adapts_response_to_view_model() {
         let response = ShowUseCaseResponseDto {
             document_annotations: vec![DocumentAnnotation {
                 source_file: "docs/a.md".to_string(),
@@ -230,59 +108,40 @@ mod tests {
             warnings: vec![],
         };
 
-        let view = adapt_response(&response);
-
-        assert_eq!(
-            view.stdout,
-            vec![
-                "Found 8 annotations".to_string(),
-                "Warnings: 0".to_string(),
-                "".to_string(),
-                "[1] docs/a.md".to_string(),
-                "    metas: 1".to_string(),
-                "    abstracts: 1".to_string(),
-                "    details: 1".to_string(),
-                "    implementations: 1".to_string(),
-                "    source: document".to_string(),
-                "".to_string(),
-                "[1] src/a.rs".to_string(),
-                "    metas: 1".to_string(),
-                "    abstracts: 1".to_string(),
-                "    details: 1".to_string(),
-                "    implementations: 1".to_string(),
-                "    source: code".to_string(),
-                "".to_string(),
-            ]
+        let view = adapt_response(
+            &response,
+            crate::dto::ShowView::List,
+            crate::dto::ShowFormat::Text,
         );
-        assert!(view.stderr.is_empty());
+
+        assert_eq!(view.document_annotations.len(), 1);
+        assert_eq!(view.code_annotations.len(), 1);
+        assert_eq!(view.view, crate::dto::ShowView::List);
+        assert_eq!(view.format, crate::dto::ShowFormat::Text);
+        assert!(view.warnings.is_empty());
     }
 
     #[test]
-    fn separates_warning_lines_into_stderr() {
+    fn preserves_warnings_in_view_model() {
         let response = ShowUseCaseResponseDto {
             document_annotations: vec![],
             code_annotations: vec![],
-            warnings: vec![
-                ScanWarning::Parse(ParseWarning {
-                    source_file: "src/main.rs".to_string(),
-                    line: 12,
-                    message: "broken".to_string(),
-                    raw_text: "@bad".to_string(),
-                }),
-                ScanWarning::Resolve(ResolveWarning {
-                    source_annotation_id: "x".to_string(),
-                    message: "missing link".to_string(),
-                }),
-            ],
+            warnings: vec![ScanWarning::Parse(ParseWarning {
+                source_file: "src/main.rs".to_string(),
+                line: 12,
+                message: "broken".to_string(),
+                raw_text: "@bad".to_string(),
+            })],
         };
 
-        let view = adapt_response(&response);
-
-        assert_eq!(view.stderr.len(), 2);
-        assert_eq!(
-            view.stderr[0],
-            "warning: skipped unknown annotation at src/main.rs:12".to_string()
+        let view = adapt_response(
+            &response,
+            crate::dto::ShowView::Summary,
+            crate::dto::ShowFormat::Json,
         );
-        assert_eq!(view.stderr[1], "warning: missing link".to_string());
+
+        assert_eq!(view.warnings.len(), 1);
+        assert_eq!(view.view, crate::dto::ShowView::Summary);
+        assert_eq!(view.format, crate::dto::ShowFormat::Json);
     }
 }

--- a/src/domains/models/annotation/code_annotation.rs
+++ b/src/domains/models/annotation/code_annotation.rs
@@ -10,6 +10,7 @@ use crate::domains::models::spec_detail::SpecDetailAnnotation;
 /// This struct represents a code-space annotation, aggregating all annotation layers for code artifacts as described in the specification.
 #[derive(Debug, Clone)]
 pub struct CodeAnnotation {
+    pub source_file: String,
     pub metas: Vec<MetaAnnotation>,
     pub abstracts: Vec<AbstractAnnotation>,
     pub details: Vec<SpecDetailAnnotation>,

--- a/src/domains/models/annotation/document_annotation.rs
+++ b/src/domains/models/annotation/document_annotation.rs
@@ -10,6 +10,7 @@ use crate::domains::models::spec_detail::SpecDetailAnnotation;
 /// This struct represents a document-space annotation, aggregating all annotation layers for document artifacts as described in the specification.
 #[derive(Debug, Clone)]
 pub struct DocumentAnnotation {
+    pub source_file: String,
     pub metas: Vec<MetaAnnotation>,
     pub abstracts: Vec<AbstractAnnotation>,
     pub details: Vec<SpecDetailAnnotation>,

--- a/src/domains/models/annotation/meta_diff.rs
+++ b/src/domains/models/annotation/meta_diff.rs
@@ -82,12 +82,14 @@ mod tests {
             links: vec![],
         };
         let doc = DocumentAnnotation {
+            source_file: "doc.md".to_string(),
             metas: vec![meta.clone()],
             abstracts: vec![],
             details: vec![],
             implementations: vec![],
         };
         let code = CodeAnnotation {
+            source_file: "code.rs".to_string(),
             metas: vec![meta.clone()],
             abstracts: vec![],
             details: vec![],
@@ -117,12 +119,14 @@ mod tests {
             links: vec![],
         };
         let doc = DocumentAnnotation {
+            source_file: "doc.md".to_string(),
             metas: vec![meta1.clone()],
             abstracts: vec![],
             details: vec![],
             implementations: vec![],
         };
         let code = CodeAnnotation {
+            source_file: "code.rs".to_string(),
             metas: vec![meta2.clone()],
             abstracts: vec![],
             details: vec![],

--- a/src/domains/services/annotation/parser.rs
+++ b/src/domains/services/annotation/parser.rs
@@ -16,7 +16,7 @@ pub struct ParseResult {
 
 /// [@st-code-domain-services-annotation-parser-parse-warning] layer: abstract, type: Structure, name: ParseWarning
 /// Represents a non-fatal issue encountered during parsing, such as malformed syntax.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ParseWarning {
     pub source_file: String,
     pub line: usize,

--- a/src/domains/services/annotation/resolver.rs
+++ b/src/domains/services/annotation/resolver.rs
@@ -51,7 +51,7 @@ pub struct ResolveResult {
 
 /// [@st-code-domain-services-annotation-resolver-resolve-warning] layer: abstract, type: Structure, name: ResolveWarning
 /// Represents an issue found during resolution, such as a missing link target or invalid layer name.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ResolveWarning {
     pub source_annotation_id: String,
     pub message: String,

--- a/src/domains/services/annotation/scanner.rs
+++ b/src/domains/services/annotation/scanner.rs
@@ -20,7 +20,7 @@ pub struct ScanResult {
 
 /// [@st-code-domain-services-annotation-scanner-scan-warning] layer: abstract, type: Structure, name: ScanWarning
 /// Wraps warnings from either the parsing or resolution stages.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ScanWarning {
     Parse(ParseWarning),
     Resolve(ResolveWarning),

--- a/src/domains/services/annotation/scanner.rs
+++ b/src/domains/services/annotation/scanner.rs
@@ -81,8 +81,9 @@ impl AnnotationScanner {
 
             if !code_path_str.is_empty() && source_file.starts_with(code_path_str) {
                 let container = code_map
-                    .entry(source_file)
+                    .entry(source_file.clone())
                     .or_insert_with(|| CodeAnnotation {
+                        source_file: source_file.clone(),
                         metas: vec![],
                         abstracts: vec![],
                         details: vec![],
@@ -96,8 +97,9 @@ impl AnnotationScanner {
                 }
             } else if !doc_path_str.is_empty() && source_file.starts_with(doc_path_str) {
                 let container = doc_map
-                    .entry(source_file)
+                    .entry(source_file.clone())
                     .or_insert_with(|| DocumentAnnotation {
+                        source_file: source_file.clone(),
                         metas: vec![],
                         abstracts: vec![],
                         details: vec![],

--- a/src/libs/config.rs
+++ b/src/libs/config.rs
@@ -25,19 +25,10 @@ impl SpecTrailConfig {
     /// # Examples
     ///
     /// ```
-    /// use std::fs;
-    /// let toml = r#"
-    /// [source]
-    /// head = "specify_manual/"
-    /// extension = "rs"
-    /// [document]
-    /// head = "docs/"
-    /// extension = "md"
-    /// [annotation]
-    /// prefix = "@spec"
-    /// "#;
-    /// fs::write("test_config.toml", toml).unwrap();
-    /// let config = SpecTrailConfig::from_file("test_config.toml").unwrap();
+    /// use SpecTrail::config::SpecTrailConfig;
+    /// let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+    ///     .join("tests/resources/test_config.toml");
+    /// let config = SpecTrailConfig::from_file(&path).unwrap();
     /// assert_eq!(config.source.head, "specify_manual/");
     /// ```
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, Box<dyn std::error::Error>> {

--- a/src/use_case/show/show_use_case.rs
+++ b/src/use_case/show/show_use_case.rs
@@ -40,65 +40,6 @@ mod tests {
     }
 
     #[test]
-    fn execute_fails_for_search_mode() {
-        let uc = ShowUseCase::new();
-        let result = uc.execute(make_request("search", "all", None));
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "show --mode search is not implemented yet"
-        );
-    }
-
-    #[test]
-    fn execute_fails_for_group_target() {
-        let uc = ShowUseCase::new();
-        let result = uc.execute(make_request("list", "group", None));
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "show --target group is not implemented yet"
-        );
-    }
-
-    #[test]
-    fn execute_fails_when_scope_is_present_with_non_search_mode() {
-        let uc = ShowUseCase::new();
-        let result = uc.execute(make_request("list", "all", Some("@st-foo")));
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "--scope is only supported with --mode search"
-        );
-    }
-
-    #[test]
-    fn execute_search_mode_is_checked_before_scope_validation() {
-        // When mode=search AND scope is given, the search-mode error should fire first
-        let uc = ShowUseCase::new();
-        let result = uc.execute(make_request("search", "all", Some("@st-foo")));
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "show --mode search is not implemented yet"
-        );
-    }
-
-    #[test]
-    fn execute_succeeds_with_list_mode_and_code_target() {
-        let uc = ShowUseCase::new();
-        let result = uc.execute(make_request("list", "code", None));
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn execute_succeeds_with_list_mode_and_document_target() {
-        let uc = ShowUseCase::new();
-        let result = uc.execute(make_request("list", "document", None));
-        assert!(result.is_ok());
-    }
-
-    #[test]
     fn execute_succeeds_with_list_mode_and_all_target() {
         let uc = ShowUseCase::new();
         let result = uc.execute(make_request("list", "all", None));
@@ -146,11 +87,9 @@ impl ShowUseCase {
         if request.mode == "search" {
             return Err("show --mode search is not implemented yet".into());
         }
-
         if request.target == "group" {
             return Err("show --target group is not implemented yet".into());
         }
-
         if request.scope.is_some() {
             return Err("--scope is only supported with --mode search".into());
         }

--- a/src/use_case/show/show_use_case.rs
+++ b/src/use_case/show/show_use_case.rs
@@ -3,7 +3,6 @@ use crate::config::SpecTrailConfig;
 use crate::domains::models::annotation::code_annotation::CodeAnnotation;
 use crate::domains::models::annotation::document_annotation::DocumentAnnotation;
 use crate::domains::services::annotation::scanner::{AnnotationScanner, ScanWarning};
-use log::info;
 use std::path::Path;
 
 /// [@st-code-use-case-show-show-use-case-request-dto] layer: abstract, type: Structure, name: ShowUseCaseRequestDto
@@ -130,16 +129,20 @@ impl ShowUseCase {
     /// # Examples
     ///
     /// ```
+    /// use SpecTrail::use_case::show::show_use_case::{ShowUseCase, ShowUseCaseRequestDto};
     /// let uc = ShowUseCase::new();
-    /// let req = ShowUseCaseRequestDto { mode: "search".into(), target: "all".into(), scope: None };
+    /// let req = ShowUseCaseRequestDto {
+    ///     mode: "search".into(),
+    ///     target: "all".into(),
+    ///     scope: None,
+    ///     config_path: None,
+    /// };
     /// assert!(uc.execute(req).is_err()); // "search" mode is not implemented
     /// ```
     pub fn execute(
         &self,
         request: ShowUseCaseRequestDto,
     ) -> Result<ShowUseCaseResponseDto, Box<dyn std::error::Error>> {
-        info!("Executing ShowUseCase with request: {:?}", request);
-
         if request.mode == "search" {
             return Err("show --mode search is not implemented yet".into());
         }
@@ -180,139 +183,10 @@ impl ShowUseCase {
         let document_annotations = scan_result.document_annotations;
         let warnings = scan_result.warnings;
 
-        // Reporting
-        self.report_annotations(&code_annotations, &document_annotations);
-
         Ok(ShowUseCaseResponseDto {
             document_annotations,
             code_annotations,
             warnings,
         })
-    }
-
-    fn report_annotations(
-        &self,
-        code_annotations: &[CodeAnnotation],
-        document_annotations: &[DocumentAnnotation],
-    ) {
-        info!("--- Annotation Report ---");
-        info!("Total Code Annotations: {}", code_annotations.len());
-        for (i, anno) in code_annotations.iter().enumerate() {
-            info!("  Code Anno [{}]:", i);
-            if !anno.metas.is_empty() {
-                for meta in &anno.metas {
-                    let link_ids: Vec<String> = meta.links.iter().map(|l| l.id.0.clone()).collect();
-                    info!(
-                        "    [Meta] id: {}, name: {}, type: {:?}, links: {:?}",
-                        meta.id.0, meta.name.0, meta.r#type, link_ids
-                    );
-                }
-            }
-            if !anno.abstracts.is_empty() {
-                for abs in &anno.abstracts {
-                    let link_ids: Vec<String> = abs.links.iter().map(|l| l.id.0.clone()).collect();
-                    info!(
-                        "    [Abstract] id: {}, name: {}, type: {:?}, links: {:?}",
-                        abs.id.0, abs.name.0, abs.r#type, link_ids
-                    );
-                }
-            }
-            if !anno.details.is_empty() {
-                for detail in &anno.details {
-                    let link_ids: Vec<String> = detail
-                        .links
-                        .iter()
-                        .map(|l| match l {
-                            crate::domains::models::spec_detail::SpecDetailLink::Abstract(a) => {
-                                a.id.0.clone()
-                            }
-                            crate::domains::models::spec_detail::SpecDetailLink::Implementation(
-                                i,
-                            ) => i.id.0.clone(),
-                        })
-                        .collect();
-                    info!(
-                        "    [Detail] id: {}, name: {}, type: {:?}, links: {:?}",
-                        detail.id.0, detail.name.0, detail.r#type, link_ids
-                    );
-                }
-            }
-            if !anno.implementations.is_empty() {
-                for impl_anno in &anno.implementations {
-                    let link_ids: Vec<String> = impl_anno.links.iter().map(|l| match l {
-                        crate::domains::models::implementation::ImplementationLink::Abstract(a) => a.id.0.clone(),
-                        crate::domains::models::implementation::ImplementationLink::SpecDetail(s) => s.id.0.clone(),
-                    }).collect();
-                    info!(
-                        "    [Implementation] id: {}, name: {}, type: {:?}, artifact: {}, links: {:?}",
-                        impl_anno.id.0,
-                        impl_anno.name.0,
-                        impl_anno.r#type,
-                        impl_anno.artifact.0,
-                        link_ids
-                    );
-                }
-            }
-        }
-
-        info!("Total Document Annotations: {}", document_annotations.len());
-        for (i, anno) in document_annotations.iter().enumerate() {
-            info!("  Document Anno [{}]:", i);
-            if !anno.metas.is_empty() {
-                for meta in &anno.metas {
-                    let link_ids: Vec<String> = meta.links.iter().map(|l| l.id.0.clone()).collect();
-                    info!(
-                        "    [Meta] id: {}, name: {}, type: {:?}, links: {:?}",
-                        meta.id.0, meta.name.0, meta.r#type, link_ids
-                    );
-                }
-            }
-            if !anno.abstracts.is_empty() {
-                for abs in &anno.abstracts {
-                    let link_ids: Vec<String> = abs.links.iter().map(|l| l.id.0.clone()).collect();
-                    info!(
-                        "    [Abstract] id: {}, name: {}, type: {:?}, links: {:?}",
-                        abs.id.0, abs.name.0, abs.r#type, link_ids
-                    );
-                }
-            }
-            if !anno.details.is_empty() {
-                for detail in &anno.details {
-                    let link_ids: Vec<String> = detail
-                        .links
-                        .iter()
-                        .map(|l| match l {
-                            crate::domains::models::spec_detail::SpecDetailLink::Abstract(a) => {
-                                a.id.0.clone()
-                            }
-                            crate::domains::models::spec_detail::SpecDetailLink::Implementation(
-                                i,
-                            ) => i.id.0.clone(),
-                        })
-                        .collect();
-                    info!(
-                        "    [Detail] id: {}, name: {}, type: {:?}, links: {:?}",
-                        detail.id.0, detail.name.0, detail.r#type, link_ids
-                    );
-                }
-            }
-            if !anno.implementations.is_empty() {
-                for impl_anno in &anno.implementations {
-                    let link_ids: Vec<String> = impl_anno.links.iter().map(|l| match l {
-                        crate::domains::models::implementation::ImplementationLink::Abstract(a) => a.id.0.clone(),
-                        crate::domains::models::implementation::ImplementationLink::SpecDetail(s) => s.id.0.clone(),
-                    }).collect();
-                    info!(
-                        "    [Implementation] id: {}, name: {}, type: {:?}, artifact: {}, links: {:?}",
-                        impl_anno.id.0,
-                        impl_anno.name.0,
-                        impl_anno.r#type,
-                        impl_anno.artifact.0,
-                        link_ids
-                    );
-                }
-            }
-        }
-        info!("-------------------------");
     }
 }

--- a/test_config.toml
+++ b/test_config.toml
@@ -6,4 +6,4 @@ extension = "rs"
 head = "docs/"
 extension = "md"
 [annotation]
-prefix = "@spec"
+prefix = "@st-code"

--- a/test_config.toml
+++ b/test_config.toml
@@ -1,0 +1,9 @@
+
+[source]
+head = "specify_manual/"
+extension = "rs"
+[document]
+head = "docs/"
+extension = "md"
+[annotation]
+prefix = "@spec"

--- a/tests/resources/test_config.toml
+++ b/tests/resources/test_config.toml
@@ -1,10 +1,9 @@
+
 [source]
 head = "specify_manual/"
 extension = ".rs"
-
 [document]
 head = "docs/"
 extension = ".md"
-
 [annotation]
-prefix = "@spec"
+prefix = "@st-code"

--- a/tests/resources/test_config.toml
+++ b/tests/resources/test_config.toml
@@ -1,0 +1,10 @@
+[source]
+head = "specify_manual/"
+extension = ".rs"
+
+[document]
+head = "docs/"
+extension = ".md"
+
+[annotation]
+prefix = "@spec"


### PR DESCRIPTION
#### Summary
This MR defines the output architecture for the `show` command and updates the specifications in `specs/006-show-command-output/` and `specify_manual/`. The main focus is on separating the concerns of data retrieval (UseCase), information granularity (View), and output representation (Format).

#### Changes
- **Architecture Refinement**: Moved the responsibility for output formatting and DTO transformation from the `UseCase` layer to the `Presentation` layer (`output` module).
- **Concept Separation**:
  - **Mode**: Fixed to `show` (UseCase processing).
  - **View**: Introduced `summary`, `list`, `group`, and `detail` to control information granularity in the Presentation layer.
  - **Format**: Introduced `text` and `json` to handle different output formats.
- **Guideline Update**: Updated `specs/0_ai_guidelines/README.md` to include a rule for recording scoped-out ideas in `specs/0_01_idea_notes/`.
- **Idea/Issue Tracking**:
  - Logged the plan to separate `search` into a new `find` command as a pending idea.
  - Logged legacy `search` usage in `specify_manual` as a pending issue.
- **Manual Update**: Synchronized `specify_manual/command_design/show_annotattion/` with the new `View`/`Format` based design.

#### Verification
- Verified that all updated Markdown files in `specs/` and `specify_manual/` are consistent with the latest consensus.
- Verified that the new rule for `0_01_idea_notes/` is correctly documented.

#### Notes
- This MR focuses on **specifications and documentation**. Implementation of these changes (e.g., refactoring `main.rs` and creating the `output` module) will be handled in subsequent tasks after this design is merged.
