### PR TITLE
Add output module for show command (text rendering & warnings)

### DIFF
--- a/src/bin/show/output/mod.rs
+++ b/src/bin/show/output/mod.rs
@@ -1,0 +1,22 @@
+mod text;
+mod warning;
+
+use crate::show_response_adapter::ShowResponseView;
+use crate::dto::ShowFormat;
+
+pub fn render(view_model: &ShowResponseView) {
+    // Render warnings to stderr if any
+    if !view_model.warnings.is_empty() {
+        warning::render_warnings(&view_model.warnings);
+    }
+
+    match view_model.format {
+        ShowFormat::Text => {
+            text::render_text(view_model);
+        }
+        ShowFormat::Json => {
+            // TODO: Implement JSON rendering
+            eprintln!("Error: JSON format is not yet implemented.");
+        }
+    }
+}

--- a/src/bin/show/output/text.rs
+++ b/src/bin/show/output/text.rs
@@ -1,0 +1,140 @@
+use crate::show_response_adapter::ShowResponseView;
+use crate::dto::ShowView;
+use SpecTrail::domains::models::annotation::code_annotation::CodeAnnotation;
+use SpecTrail::domains::models::annotation::document_annotation::DocumentAnnotation;
+
+pub fn render_text(view_model: &ShowResponseView) {
+    match view_model.view {
+        ShowView::Summary => {
+            render_summary(view_model);
+        }
+        ShowView::List => {
+            render_list(view_model);
+        }
+        ShowView::Group => {
+            // Currently same as list
+            render_list(view_model);
+        }
+        ShowView::Detail => {
+            render_detail(view_model);
+        }
+    }
+}
+
+fn render_summary(view_model: &ShowResponseView) {
+    let doc_count = view_model.document_annotations.len();
+    let code_count = view_model.code_annotations.len();
+    let total_annotations = count_total_annotations(view_model);
+
+    println!("Summary:");
+    println!("  Total annotations: {}", total_annotations);
+    println!("  Document files: {}", doc_count);
+    println!("  Code files: {}", code_count);
+}
+
+fn render_list(view_model: &ShowResponseView) {
+    if view_model.document_annotations.is_empty() && view_model.code_annotations.is_empty() {
+        println!("No annotations found.");
+        return;
+    }
+
+    if !view_model.document_annotations.is_empty() {
+        println!("Document Annotations:");
+        append_file_section(&view_model.document_annotations, "document");
+    }
+
+    if !view_model.code_annotations.is_empty() {
+        println!("Code Annotations:");
+        append_file_section(&view_model.code_annotations, "code");
+    }
+}
+
+fn render_detail(view_model: &ShowResponseView) {
+    if view_model.document_annotations.is_empty() && view_model.code_annotations.is_empty() {
+        println!("No annotations found.");
+        return;
+    }
+
+    for doc in &view_model.document_annotations {
+        println!("File: {} (document)", doc.source_file);
+        for meta in &doc.metas {
+            println!("  [Meta] ID: {}, Name: {}", meta.id.0, meta.name.0);
+        }
+        for abs in &doc.abstracts {
+            println!("  [Abstract] ID: {}, Name: {}", abs.id.0, abs.name.0);
+        }
+        for det in &doc.details {
+            println!("  [Detail] ID: {}, Name: {}", det.id.0, det.name.0);
+        }
+        for imp in &doc.implementations {
+            println!("  [Implementation] ID: {}", imp.id.0);
+        }
+        println!();
+    }
+
+    for code in &view_model.code_annotations {
+        println!("File: {} (code)", code.source_file);
+        for meta in &code.metas {
+            println!("  [Meta] ID: {}, Name: {}", meta.id.0, meta.name.0);
+        }
+        for abs in &code.abstracts {
+            println!("  [Abstract] ID: {}, Name: {}", abs.id.0, abs.name.0);
+        }
+        for det in &code.details {
+            println!("  [Detail] ID: {}, Name: {}", det.id.0, det.name.0);
+        }
+        for imp in &code.implementations {
+            println!("  [Implementation] ID: {}", imp.id.0);
+        }
+        println!();
+    }
+}
+
+fn append_file_section(annotations: &[impl AnnotationGroupView], label: &str) {
+    let mut items: Vec<_> = annotations.iter().collect();
+    items.sort_by(|a, b| a.source_file().cmp(b.source_file()));
+
+    for (index, annotation) in items.into_iter().enumerate() {
+        println!("[{}] {}", index + 1, annotation.source_file());
+        println!("    metas: {}", annotation.meta_count());
+        println!("    abstracts: {}", annotation.abstract_count());
+        println!("    details: {}", annotation.detail_count());
+        println!("    implementations: {}", annotation.implementation_count());
+        println!("    source: {}", label);
+        println!();
+    }
+}
+
+fn count_total_annotations(view_model: &ShowResponseView) -> usize {
+    let doc_sum: usize = view_model.document_annotations.iter().map(|a| 
+        a.metas.len() + a.abstracts.len() + a.details.len() + a.implementations.len()
+    ).sum();
+    let code_sum: usize = view_model.code_annotations.iter().map(|a| 
+        a.metas.len() + a.abstracts.len() + a.details.len() + a.implementations.len()
+    ).sum();
+    doc_sum + code_sum
+}
+
+trait AnnotationGroupView {
+    fn source_file(&self) -> &str;
+    fn meta_count(&self) -> usize;
+    fn abstract_count(&self) -> usize;
+    fn detail_count(&self) -> usize;
+    fn implementation_count(&self) -> usize;
+}
+
+impl AnnotationGroupView for CodeAnnotation {
+    fn source_file(&self) -> &str { &self.source_file }
+    fn meta_count(&self) -> usize { self.metas.len() }
+    fn abstract_count(&self) -> usize { self.abstracts.len() }
+    fn detail_count(&self) -> usize { self.details.len() }
+    fn implementation_count(&self) -> usize { self.implementations.len() }
+}
+
+impl AnnotationGroupView for DocumentAnnotation {
+    fn source_file(&self) -> &str { &self.source_file }
+    fn meta_count(&self) -> usize { self.metas.len() }
+    fn abstract_count(&self) -> usize { self.abstracts.len() }
+    fn detail_count(&self) -> usize { self.details.len() }
+    fn implementation_count(&self) -> usize { self.implementations.len() }
+}

--- a/src/bin/show/output/warning.rs
+++ b/src/bin/show/output/warning.rs
@@ -1,0 +1,17 @@
+use SpecTrail::domains::services::annotation::scanner::ScanWarning;
+
+pub fn render_warnings(warnings: &[ScanWarning]) {
+    for warning in warnings {
+        eprintln!("{}", format_warning(warning));
+    }
+}
+
+fn format_warning(warning: &ScanWarning) -> String {
+    match warning {
+        ScanWarning::Parse(pw) => format!(
+            "warning: skipped unknown annotation at {}:{}",
+            pw.source_file, pw.line
+        ),
+        ScanWarning::Resolve(rw) => format!("warning: {}", rw.message),
+    }
+}


### PR DESCRIPTION
This merge request introduces a new output module for the show command, providing structured output rendering and warning display. Key changes include:
Added src/bin/show/output/mod.rs to manage output format selection and warning handling.
Implemented src/bin/show/output/text.rs for rendering annotation data in text format, supporting summary, list, group, and detail views.
Added src/bin/show/output/warning.rs to render scan warnings to stderr.
The output module separates concerns for future extensibility (e.g., JSON output).
All code and comments are written in English, following repository guidelines.
This refactoring improves maintainability and prepares the codebase for additional output formats. No breaking changes to existing interfaces.